### PR TITLE
Improve password safety with encryption

### DIFF
--- a/backend/src/__tests__/authUtils.tests.ts
+++ b/backend/src/__tests__/authUtils.tests.ts
@@ -15,4 +15,9 @@ describe('Auth util tests', () => {
     const result = verifyHashedPassword(password, hashedPassword);
     expect(result).toBe(true);
   });
+
+  it('should generate a password', async () => {
+    console.log(hashPassword('test'));
+    console.log(hashPassword('test2'));
+  });
 });

--- a/backend/src/__tests__/authUtils.tests.ts
+++ b/backend/src/__tests__/authUtils.tests.ts
@@ -1,0 +1,18 @@
+import { hashPassword, verifyHashedPassword } from '../utils/authUtils';
+
+describe('Auth util tests', () => {
+  it('should generate a different hash for same password', async () => {
+    const password = 'password';
+    const hash1 = hashPassword(password);
+    const hash2 = hashPassword(password);
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('should verify password vs the hashed password', async () => {
+    const password = 'password';
+    const hashedPassword = hashPassword(password);
+    console.log(hashedPassword.split(':')[0]);
+    const result = verifyHashedPassword(password, hashedPassword);
+    expect(result).toBe(true);
+  });
+});

--- a/backend/src/__tests__/backend.tests.ts
+++ b/backend/src/__tests__/backend.tests.ts
@@ -23,6 +23,7 @@ describe('Backend tests', () => {
           .post('/api/login')
           .send({ username: 'test', password: 'test' });
         console.log(response.headers['set-cookie']);
+        expect(response.statusCode).toBe(200);
         expect(response.headers['set-cookie']).toBeDefined();
       });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -51,8 +51,18 @@ app.get('/api/users', async (req: Request, res: Response) => {
 });
 
 const userDatabase = [
-  { id: 'id1', username: 'test', password: 'test' },
-  { id: 'id2', username: 'test2', password: 'test2' },
+  {
+    id: 'id1',
+    username: 'test',
+    password:
+      '8Gnhiz3mhf2YrPx/ws+fnpvmUVyi0RSp7AmDGL/aui4P+9CUhEmIzPK0IaQtuhdjWaYJDdRtvutjXKPar/oeasD55KZRCKFMkTLFQjs5N90fsBe5o6EOJ9DXxhgLQc/UOAjpeth9cHiOy3NxpL8qgWTgCWZRTWk9grzHD5y0+cE=:gKvdYWujo142pvoRqBtgUHzyo5r9kKkVb7VdbdtCFRSxYb4ZpcOQtanLFz1c9sCrYk3E2SI3sJabPJN16ZmZsF0hD2HJJjDIER9LoZx4HQZoBo/F4f0NLoc1kuHq+IrM2kkoYrBIQFA1umExAl7pUuKXsBcJCZU7n8ix+6kgJhSd3yp6I4vKNOMiQDjyBuQTil1FLaW1mxOYZ1rttS6zlaGp93jWLqxjps59/UsQMO2MRFetGPPRzKhBnYE3iT52Irw2YGqs2rg1VA7MvxT65hQmsmsEcE74Jg9glMe53RW+ETqmCDjD2lPfLPLVQWq6CT+X5aCsZzaDxEm4tkjPDtb6f8hH5fx+PnwtLK4HW12iO0GoCKEzcK4qetEBSjKjms6yfJFUKIR6g4hV2JTEwbLFAJ6HpVS7SpY00l27zQPelqgXFIJcU+eyPY2i+uyG+y/D6bToCP8OQ6c2MpXCd/a9hS/30rcHrJJMdZr+YBwlIPZyjcF1Wl/iLp5KGaRYhNtICaOhWGYybgVA/Ov4RLnNRLBaRsNfLKR4QSxGFDpNBVd/RyJ0NWvpo8tNJkYO6bcvKJtXnVLa7rqT2Pw864z3wyguk9X0OPGhgNzrDdUIrUyBTvNI/vDe+oIb5h7dodlZUb5QFU9eX8MhcA6PuffKbxk82nAodgnexCEua2c=',
+  },
+  {
+    id: 'id2',
+    username: 'test2',
+    password:
+      'F3p/aAZOfgG6EqaZwSIz7mKO5zw34dxUnap78CZa+UbF5/EyYL5WJy5XiXd7d5paOREsLHj1ab5SV9f6sAi5Gl8yWZerbCl+LaP3ufhjZxAe5Sgoo7MFY1R1pFmzKxebhrd3ahLsLHerGjMEo9NaDwOsuOUGdLMofo7PLurZJj0=:cnufLXQxebBbF6AAw7ct5//n6+EbZFNSCr2wARsluQ1XeGdw9BQI08d5SX3ko4olnSEAybdiUq1ROLss4XSZmbrr4TRpYG2agrrUgekMJdVtumjSSkyCHE9OEpIZ1eOA/KaojCEZRN4UCuERWbW6GVmevm0b4Z78sSXjkBQ2eBX/YxrIyd2MIuI/ES4KntqnhyxtO6xxIplQvfVJrRO//ZzjDby5jggO7a4rSzxNKT78GY8zT5RQ6H+ma71D44UttZMLDuYb+2NOtyaQO67qKKiw0kPAtSCf7E2IK1XrjyLvOvToXXpAebkRhrT6vGruRJDUUqISn7AR6byiPOBe3Kt2epZl0gfzY00c7KZTM2BDtIwEJPinptUHIKwtncpuFxU4Iahy8dGTSiiKVD8VHWAmg7LukWG5kXBf0++9/X9Pdk3BVZGtQcbBsnA1malKTJ50IDZDA3a1eTHZEaF9Ta1tSH1/iONA3EJ3uAwIa99r2dFnOLv8NzdhWlNJjzp2ILIJxQR6HBXxOyan6HMa9FIlaVxbSmnkI9dx1TVOztkqZGE9CozY1pIbBqXJlK4Bmj9HGvsDDmdIReP/HeU8CnShoGhH0zqtA+re4OgbPIuaAXfOKzP2/npG9XkmlGVjL00zCpUUZMCkNeIUJG/m8I7Moqnz511uzeDpPDP/eNo=',
+  },
 ];
 
 declare module 'express-session' {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ This is the conventional way of authenticating a client application to a backend
 Install with npm i express-session --save, when using typescript we install the types with npm i @types/express-session --save-dev
  */
 import session from 'express-session';
+import { verifyHashedPassword } from './utils/authUtils';
 
 export const app = express();
 connectToMongoDB().then();
@@ -75,15 +76,13 @@ declare module 'express-session' {
 app.post('/api/login', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { username, password } = req.body; // we extract username and password from the request body. We have typed the request object and specified how the request body looks.
-    console.log(req.body);
     //find the user
     const user = userDatabase.find((user) => user.username === username);
-    if (!user || user.password !== password) {
+    if (!user || !verifyHashedPassword(password, user.password)) {
       //if no user is found or the user.password is not equal to password in the body, we return 401
       return res.status(401).json({ msg: 'Unauthorized' });
     }
     req.session.userId = user.id;
-    console.log(req.session); //print the session to show that the userId is set
     return res.status(200).json({ msg: 'Logged in' });
   } catch (error: unknown) {
     // we type everything, error is unknown so we type it as such so we have to assert what it is later.

--- a/backend/src/utils/authUtils.ts
+++ b/backend/src/utils/authUtils.ts
@@ -1,0 +1,16 @@
+import crypto from 'crypto';
+
+const iterations = 10000;
+const keyLength = 512;
+
+export const hashPassword = (password: string) => {
+  const salt = crypto.randomBytes(128).toString('base64');
+  return `${salt}:${crypto.pbkdf2Sync(password, salt, iterations, keyLength, 'sha512').toString('base64')}`;
+};
+
+export const verifyHashedPassword = (password: string, hashedPassword: string) => {
+  const [salt, hash] = hashedPassword.split(':');
+  return (
+    hash === crypto.pbkdf2Sync(password, salt, iterations, keyLength, 'sha512').toString('base64')
+  );
+};

--- a/backend/src/utils/authUtils.ts
+++ b/backend/src/utils/authUtils.ts
@@ -4,13 +4,13 @@ const iterations = 10000;
 const keyLength = 512;
 
 export const hashPassword = (password: string) => {
-  const salt = crypto.randomBytes(128).toString('base64');
-  return `${salt}:${crypto.pbkdf2Sync(password, salt, iterations, keyLength, 'sha512').toString('base64')}`;
+  const salt = crypto.randomBytes(128).toString('base64'); //generate a random salt.
+  return `${salt}:${crypto.pbkdf2Sync(password, salt, iterations, keyLength, 'sha512').toString('base64')}`; //hash the password with the salt and return the salt and the hash concatenated with a colon.
 };
 
 export const verifyHashedPassword = (password: string, hashedPassword: string) => {
-  const [salt, hash] = hashedPassword.split(':');
+  const [salt, hash] = hashedPassword.split(':'); //separate the salt and the hash from the hashed password string.
   return (
-    hash === crypto.pbkdf2Sync(password, salt, iterations, keyLength, 'sha512').toString('base64')
+    hash === crypto.pbkdf2Sync(password, salt, iterations, keyLength, 'sha512').toString('base64') //compare the hash of the password with the hash in the hashed password string.
   );
 };


### PR DESCRIPTION
In this PR I have added password one way encryption. I created a new utils file with hash and verifyHash functions to be able to encrypt the passwords.

I started with writing a test for encrypting the password. then I implemented the function in the authUtils.ts file to verify that two passwords with same test (test) generated different hashes

After that i wrote tests to verify a string generates the same hash as the hashed password, the hashed password is formatted as {salt}:{hash}, so a stored hash we will apply the salt in the verify function. You can read comments in the code in utils/authUtils.ts

Updated the userDatabase (the array in index.ts) with encprypted passwords.  

Now my backend tests fails, we need to verify the hash in the login api. So i refactored the post('/api/login') to not just check if the received password is equal to user.password, but i used the stored hash in user.password to verify that the received password hashes to the same hash.

Now tests are working again

